### PR TITLE
DRAFT: Alien::libgraphqlparser to get the LIBS and CCFLAGS for the shared library

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use 5.008009;
 use ExtUtils::MakeMaker;
+use Alien::libgraphqlparser;
 
 WriteMakefile(
     NAME           => 'Parser::GraphQL::XS',
@@ -7,6 +8,9 @@ WriteMakefile(
     ABSTRACT_FROM  => 'lib/Parser/GraphQL/XS.pm',
     LICENSE        => 'mit',
     MIN_PERL_VERSION => 5.018000,
+    CONFIGURE_REQUIRES => {
+        'Alien::libgraphqlparser' => 0.01,
+    },
     PREREQ_PM      => {
         'XSLoader'     => 0,
     },
@@ -19,7 +23,7 @@ WriteMakefile(
     AUTHOR         => [
         'Gonzalo Diethelm (gonzus@cpan.org)',
     ],
-    LIBS           => [ '-lgraphqlparser' ],
+    LIBS           => [ Alien::libgraphqlparser->libs || '-lgraphqlparser' ],
     OBJECT         => '$(O_FILES)',
     META_MERGE     => {
         'meta-spec' => { version => 2 },
@@ -48,6 +52,7 @@ sub cflags {
         comment
     /;
     $self->{CCFLAGS} .= " -W$_" for @warning_flags_always;
+    $self->{CCFLAGS} .= " " . Alien::libgraphqlparser->cflags // '';
 
     foreach (@cflags) {
         $_ = "CCFLAGS = $self->{CCFLAGS}" if /^CCFLAGS/;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,18 @@
 use 5.008009;
+use Config;
 use ExtUtils::MakeMaker;
 use Alien::libgraphqlparser;
+
+my $linker_flags = $Config{lddlflags} // '';
+$linker_flags   .= " ";
+# ->libs_static is actually Libs + Libs.private; the out-in-the-wild version
+# of libgraphqlparser leaves that empty, while the version built by
+# `Alien::libgraphqlparser` puts the static library there.
+# So if we are linking against an OS-provided .so, everything works as
+# before, but if we are linking against the private version built by
+# Alien::libgraphqlparser, we end up statically linking against it,
+# since otherwise we would not be able to dlopen() it.
+$linker_flags   .= Alien::libgraphqlparser->libs_static;
 
 WriteMakefile(
     NAME           => 'Parser::GraphQL::XS',
@@ -23,7 +35,7 @@ WriteMakefile(
     AUTHOR         => [
         'Gonzalo Diethelm (gonzus@cpan.org)',
     ],
-    LIBS           => [ Alien::libgraphqlparser->libs || '-lgraphqlparser' ],
+    LDDLFLAGS      => $linker_flags,
     OBJECT         => '$(O_FILES)',
     META_MERGE     => {
         'meta-spec' => { version => 2 },


### PR DESCRIPTION
Turns out that package managers often don't carry libgraphqlparser; I was trying to get this running in alpine and it was missing there.

Ended up forking libgraphqlparser (https://github.com/Hugmeir/libgraphqlparser) and writing a Alien::libgraphqlparser (https://github.com/Hugmeir/p5-alien-libgraphqlparser)